### PR TITLE
feature/functions-support

### DIFF
--- a/fol-interpreter/src/main/java/com/foxowlet/fol/interpreter/InterpretationContext.java
+++ b/fol-interpreter/src/main/java/com/foxowlet/fol/interpreter/InterpretationContext.java
@@ -21,4 +21,6 @@ public interface InterpretationContext {
     default <T> T interpret(Expression expression, Class<T> tClass, String errorMessage) {
         return ReflectionUtils.as(interpret(expression), tClass, TypeException.prepare(errorMessage));
     }
+
+    int allocateFunction();
 }

--- a/fol-interpreter/src/main/java/com/foxowlet/fol/interpreter/Interpreter.java
+++ b/fol-interpreter/src/main/java/com/foxowlet/fol/interpreter/Interpreter.java
@@ -26,7 +26,8 @@ public class Interpreter {
                 new IntLiteralInterpreter(),
                 new AdditionInterpreter(),
                 new LambdaInterpreter(),
-                new FunctionCallInterpreter()
+                new FunctionCallInterpreter(),
+                new FunctionDeclInterpreter()
         ).forEach(Interpreter::register);
     }
 

--- a/fol-interpreter/src/main/java/com/foxowlet/fol/interpreter/Interpreter.java
+++ b/fol-interpreter/src/main/java/com/foxowlet/fol/interpreter/Interpreter.java
@@ -24,7 +24,9 @@ public class Interpreter {
                 new AssignmentInterpreter(),
                 new BlockInterpreter(),
                 new IntLiteralInterpreter(),
-                new AdditionInterpreter()
+                new AdditionInterpreter(),
+                new LambdaInterpreter(),
+                new FunctionCallInterpreter()
         ).forEach(Interpreter::register);
     }
 
@@ -62,9 +64,11 @@ public class Interpreter {
 
     public final class Context implements InterpretationContext {
         private final Map<String, Object> symbolMap;
+        private int functionId;
 
         private Context() {
             this.symbolMap = new HashMap<>();
+            this.functionId = 0;
         }
 
         @Override
@@ -91,6 +95,11 @@ public class Interpreter {
         @Override
         public Object interpret(Expression expression) {
             return Interpreter.this.interpret(expression, this);
+        }
+
+        @Override
+        public int allocateFunction() {
+            return ++functionId;
         }
     }
 }

--- a/fol-interpreter/src/main/java/com/foxowlet/fol/interpreter/expression/FunctionCallInterpreter.java
+++ b/fol-interpreter/src/main/java/com/foxowlet/fol/interpreter/expression/FunctionCallInterpreter.java
@@ -1,0 +1,16 @@
+package com.foxowlet.fol.interpreter.expression;
+
+import com.foxowlet.fol.ast.FunctionCall;
+import com.foxowlet.fol.interpreter.InterpretationContext;
+import com.foxowlet.fol.interpreter.internal.ReflectionUtils;
+import com.foxowlet.fol.interpreter.model.Function;
+import com.foxowlet.fol.interpreter.model.Value;
+
+public class FunctionCallInterpreter implements ExpressionInterpreter<FunctionCall> {
+    @Override
+    public Object interpret(FunctionCall expression, InterpretationContext context) {
+        Value value = context.interpret(expression.target(), Value.class);
+        Function function = ReflectionUtils.as(value.value(), Function.class);
+        return context.interpret(function.body());
+    }
+}

--- a/fol-interpreter/src/main/java/com/foxowlet/fol/interpreter/expression/FunctionDeclInterpreter.java
+++ b/fol-interpreter/src/main/java/com/foxowlet/fol/interpreter/expression/FunctionDeclInterpreter.java
@@ -2,7 +2,6 @@ package com.foxowlet.fol.interpreter.expression;
 
 import com.foxowlet.fol.ast.*;
 import com.foxowlet.fol.interpreter.InterpretationContext;
-import com.foxowlet.fol.interpreter.model.Variable;
 
 public class FunctionDeclInterpreter implements ExpressionInterpreter<FunctionDecl> {
     @Override
@@ -11,13 +10,7 @@ public class FunctionDeclInterpreter implements ExpressionInterpreter<FunctionDe
         Type type = createType(expression);
         VarDecl functionSymbol = new VarDecl(expression.name(), type);
         Assignment binding = new Assignment(functionSymbol, lambda);
-        // Technically, we don't need an exact class here
-        // But perform cast to ensure that assignment returns variable
-        // So we will fail fast in the implementation changes
-        // Yeah, hidden coupling ¯\_(ツ)_/¯
-        // But otherwise we will need to duplicate LambdaInterpreter logic here
-        // TODO: try to rework this (possibly by extracting lambda interpretation logic somewhere)
-        return context.interpret(binding, Variable.class);
+        return context.interpret(binding);
     }
 
     private Type createType(FunctionDecl expression) {

--- a/fol-interpreter/src/main/java/com/foxowlet/fol/interpreter/expression/FunctionDeclInterpreter.java
+++ b/fol-interpreter/src/main/java/com/foxowlet/fol/interpreter/expression/FunctionDeclInterpreter.java
@@ -1,0 +1,35 @@
+package com.foxowlet.fol.interpreter.expression;
+
+import com.foxowlet.fol.ast.*;
+import com.foxowlet.fol.interpreter.InterpretationContext;
+import com.foxowlet.fol.interpreter.model.Variable;
+
+public class FunctionDeclInterpreter implements ExpressionInterpreter<FunctionDecl> {
+    @Override
+    public Object interpret(FunctionDecl expression, InterpretationContext context) {
+        Lambda lambda = new Lambda(expression.params(), expression.body());
+        Type type = createType(expression);
+        VarDecl functionSymbol = new VarDecl(expression.name(), type);
+        Assignment binding = new Assignment(functionSymbol, lambda);
+        // Technically, we don't need an exact class here
+        // But perform cast to ensure that assignment returns variable
+        // So we will fail fast in the implementation changes
+        // Yeah, hidden coupling ¯\_(ツ)_/¯
+        // But otherwise we will need to duplicate LambdaInterpreter logic here
+        // TODO: try to rework this (possibly by extracting lambda interpretation logic somewhere)
+        return context.interpret(binding, Variable.class);
+    }
+
+    private Type createType(FunctionDecl expression) {
+        FormalParameter[] params = expression.params().toArray(new FormalParameter[0]);
+        Type type = expression.returnType();
+        if (params.length == 0) {
+            return new FunctionType(new ScalarType(new Symbol("Unit")), type);
+        }
+        // left fold types to produce correct function type
+        for (int i = params.length - 1; i >= 0; --i) {
+            type = new FunctionType(params[i].type(), type);
+        }
+        return type;
+    }
+}

--- a/fol-interpreter/src/main/java/com/foxowlet/fol/interpreter/expression/LambdaInterpreter.java
+++ b/fol-interpreter/src/main/java/com/foxowlet/fol/interpreter/expression/LambdaInterpreter.java
@@ -25,9 +25,7 @@ public class LambdaInterpreter implements ExpressionInterpreter<Lambda> {
         return function;
     }
 
-    private List<FunctionParameter> convertParams(
-            List<FormalParameter> params,
-            InterpretationContext context) {
+    private List<FunctionParameter> convertParams(List<FormalParameter> params, InterpretationContext context) {
         return params.stream()
                 .map(param -> convertParam(context, param))
                 .toList();

--- a/fol-interpreter/src/main/java/com/foxowlet/fol/interpreter/expression/LambdaInterpreter.java
+++ b/fol-interpreter/src/main/java/com/foxowlet/fol/interpreter/expression/LambdaInterpreter.java
@@ -1,0 +1,41 @@
+package com.foxowlet.fol.interpreter.expression;
+
+import com.foxowlet.fol.ast.FormalParameter;
+import com.foxowlet.fol.ast.Lambda;
+import com.foxowlet.fol.interpreter.InterpretationContext;
+import com.foxowlet.fol.interpreter.model.FunctionParameter;
+import com.foxowlet.fol.interpreter.model.Function;
+import com.foxowlet.fol.interpreter.model.type.TypeDescriptor;
+import com.foxowlet.fol.interpreter.type.TypeInterpreter;
+
+import java.util.List;
+
+public class LambdaInterpreter implements ExpressionInterpreter<Lambda> {
+    private final TypeInterpreter typeInterpreter;
+
+    public LambdaInterpreter() {
+        typeInterpreter = new TypeInterpreter();
+    }
+
+    @Override
+    public Object interpret(Lambda expression, InterpretationContext context) {
+        int id = context.allocateFunction();
+        Function function = new Function(id, convertParams(expression.params(), context), expression.body());
+        context.registerSymbol(String.valueOf(id), function);
+        return function;
+    }
+
+    private List<FunctionParameter> convertParams(
+            List<FormalParameter> params,
+            InterpretationContext context) {
+        return params.stream()
+                .map(param -> convertParam(context, param))
+                .toList();
+    }
+
+    private FunctionParameter convertParam(InterpretationContext context, FormalParameter param) {
+        String paramName = param.name().name();
+        TypeDescriptor paramType = typeInterpreter.interpret(param.type(), context);
+        return new FunctionParameter(paramName, paramType);
+    }
+}

--- a/fol-interpreter/src/main/java/com/foxowlet/fol/interpreter/expression/VarDeclInterpreter.java
+++ b/fol-interpreter/src/main/java/com/foxowlet/fol/interpreter/expression/VarDeclInterpreter.java
@@ -4,12 +4,19 @@ import com.foxowlet.fol.ast.VarDecl;
 import com.foxowlet.fol.interpreter.InterpretationContext;
 import com.foxowlet.fol.interpreter.model.MemoryLocation;
 import com.foxowlet.fol.interpreter.model.Variable;
-import com.foxowlet.fol.interpreter.model.type.Type;
+import com.foxowlet.fol.interpreter.model.type.TypeDescriptor;
+import com.foxowlet.fol.interpreter.type.TypeInterpreter;
 
 public class VarDeclInterpreter implements ExpressionInterpreter<VarDecl> {
+    private final TypeInterpreter typeInterpreter;
+
+    public VarDeclInterpreter() {
+        typeInterpreter = new TypeInterpreter();
+    }
+
     @Override
     public Object interpret(VarDecl varDecl, InterpretationContext context) {
-        Type type = context.interpret(varDecl.type(), Type.class);
+        TypeDescriptor type = typeInterpreter.interpret(varDecl.type(), context);
         MemoryLocation memory = context.allocateMemory(type.size());
         String varName = varDecl.variable().name();
         Variable variable = new Variable(memory, varName, type);

--- a/fol-interpreter/src/main/java/com/foxowlet/fol/interpreter/model/Function.java
+++ b/fol-interpreter/src/main/java/com/foxowlet/fol/interpreter/model/Function.java
@@ -1,0 +1,12 @@
+package com.foxowlet.fol.interpreter.model;
+
+import com.foxowlet.fol.ast.Block;
+
+import java.util.List;
+
+public record Function(int id, List<FunctionParameter> params, Block body) implements Value {
+    @Override
+    public Object value() {
+        return this;
+    }
+}

--- a/fol-interpreter/src/main/java/com/foxowlet/fol/interpreter/model/FunctionParameter.java
+++ b/fol-interpreter/src/main/java/com/foxowlet/fol/interpreter/model/FunctionParameter.java
@@ -1,0 +1,6 @@
+package com.foxowlet.fol.interpreter.model;
+
+import com.foxowlet.fol.interpreter.model.type.TypeDescriptor;
+
+public record FunctionParameter(String name, TypeDescriptor type) {
+}

--- a/fol-interpreter/src/main/java/com/foxowlet/fol/interpreter/model/Variable.java
+++ b/fol-interpreter/src/main/java/com/foxowlet/fol/interpreter/model/Variable.java
@@ -1,8 +1,8 @@
 package com.foxowlet.fol.interpreter.model;
 
-import com.foxowlet.fol.interpreter.model.type.Type;
+import com.foxowlet.fol.interpreter.model.type.TypeDescriptor;
 
-public record Variable(MemoryLocation memory, String name, Type type) implements Value {
+public record Variable(MemoryLocation memory, String name, TypeDescriptor type) implements Value {
     @Override
     public Object value() {
         byte[] data = new byte[type.size()];

--- a/fol-interpreter/src/main/java/com/foxowlet/fol/interpreter/model/type/FunctionTypeDescriptor.java
+++ b/fol-interpreter/src/main/java/com/foxowlet/fol/interpreter/model/type/FunctionTypeDescriptor.java
@@ -1,0 +1,39 @@
+package com.foxowlet.fol.interpreter.model.type;
+
+import com.foxowlet.fol.interpreter.InterpretationContext;
+import com.foxowlet.fol.interpreter.internal.ReflectionUtils;
+import com.foxowlet.fol.interpreter.model.Function;
+
+public class FunctionTypeDescriptor implements TypeDescriptor {
+    private final IntType idType;
+    private final InterpretationContext context;
+    private final TypeDescriptor argumentType;
+    private final TypeDescriptor returnType;
+
+    public FunctionTypeDescriptor(InterpretationContext context, TypeDescriptor argumentType, TypeDescriptor returnType) {
+        this.context = context;
+        this.argumentType = argumentType;
+        this.returnType = returnType;
+        this.idType = new IntType();
+    }
+
+    @Override
+    public String name() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int size() {
+        return idType.size();
+    }
+
+    @Override
+    public byte[] encode(Object value) {
+        return idType.encode(ReflectionUtils.as(value, Function.class).id());
+    }
+
+    @Override
+    public Object decode(byte[] data) {
+        return context.lookupSymbol(String.valueOf(idType.decode(data)));
+    }
+}

--- a/fol-interpreter/src/main/java/com/foxowlet/fol/interpreter/model/type/FunctionTypeDescriptor.java
+++ b/fol-interpreter/src/main/java/com/foxowlet/fol/interpreter/model/type/FunctionTypeDescriptor.java
@@ -4,6 +4,8 @@ import com.foxowlet.fol.interpreter.InterpretationContext;
 import com.foxowlet.fol.interpreter.internal.ReflectionUtils;
 import com.foxowlet.fol.interpreter.model.Function;
 
+import java.util.Objects;
+
 public class FunctionTypeDescriptor implements TypeDescriptor {
     private final IntType idType;
     private final InterpretationContext context;
@@ -15,6 +17,14 @@ public class FunctionTypeDescriptor implements TypeDescriptor {
         this.argumentType = argumentType;
         this.returnType = returnType;
         this.idType = new IntType();
+    }
+
+    public TypeDescriptor argumentType() {
+        return argumentType;
+    }
+
+    public TypeDescriptor returnType() {
+        return returnType;
     }
 
     @Override
@@ -35,5 +45,18 @@ public class FunctionTypeDescriptor implements TypeDescriptor {
     @Override
     public Object decode(byte[] data) {
         return context.lookupSymbol(String.valueOf(idType.decode(data)));
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) return true;
+        if (object == null || getClass() != object.getClass()) return false;
+        FunctionTypeDescriptor that = (FunctionTypeDescriptor) object;
+        return Objects.equals(argumentType, that.argumentType) && Objects.equals(returnType, that.returnType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(argumentType, returnType);
     }
 }

--- a/fol-interpreter/src/main/java/com/foxowlet/fol/interpreter/model/type/TypeDescriptor.java
+++ b/fol-interpreter/src/main/java/com/foxowlet/fol/interpreter/model/type/TypeDescriptor.java
@@ -1,6 +1,6 @@
 package com.foxowlet.fol.interpreter.model.type;
 
-public interface Type {
+public interface TypeDescriptor {
     String name();
     int size();
     byte[] encode(Object value);

--- a/fol-interpreter/src/main/java/com/foxowlet/fol/interpreter/model/type/UnitType.java
+++ b/fol-interpreter/src/main/java/com/foxowlet/fol/interpreter/model/type/UnitType.java
@@ -1,0 +1,23 @@
+package com.foxowlet.fol.interpreter.model.type;
+
+public class UnitType implements TypeDescriptor {
+    @Override
+    public String name() {
+        return "Unit";
+    }
+
+    @Override
+    public int size() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public byte[] encode(Object value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object decode(byte[] data) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/fol-interpreter/src/main/java/com/foxowlet/fol/interpreter/model/type/UnitType.java
+++ b/fol-interpreter/src/main/java/com/foxowlet/fol/interpreter/model/type/UnitType.java
@@ -1,9 +1,13 @@
 package com.foxowlet.fol.interpreter.model.type;
 
+import java.util.Objects;
+
 public class UnitType implements TypeDescriptor {
+    private static final String NAME = "Unit";
+
     @Override
     public String name() {
-        return "Unit";
+        return NAME;
     }
 
     @Override
@@ -19,5 +23,16 @@ public class UnitType implements TypeDescriptor {
     @Override
     public Object decode(byte[] data) {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) return true;
+        return object != null && getClass() == object.getClass();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(NAME);
     }
 }

--- a/fol-interpreter/src/main/java/com/foxowlet/fol/interpreter/model/type/WholeNumberType.java
+++ b/fol-interpreter/src/main/java/com/foxowlet/fol/interpreter/model/type/WholeNumberType.java
@@ -3,6 +3,8 @@ package com.foxowlet.fol.interpreter.model.type;
 import com.foxowlet.fol.interpreter.exception.IncompatibleTypeException;
 import com.foxowlet.fol.interpreter.exception.InvalidTypeSizeException;
 
+import java.util.Objects;
+
 public abstract class WholeNumberType<T extends Number> implements TypeDescriptor {
     private final Class<T> javaClass;
     private final String folTypeName;
@@ -45,4 +47,18 @@ public abstract class WholeNumberType<T extends Number> implements TypeDescripto
     }
 
     protected abstract Object getValue(long longVal);
+
+    // TODO: use singletons at least for predefined types?
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) return true;
+        if (object == null || getClass() != object.getClass()) return false;
+        WholeNumberType<?> that = (WholeNumberType<?>) object;
+        return Objects.equals(folTypeName, that.folTypeName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(folTypeName);
+    }
 }

--- a/fol-interpreter/src/main/java/com/foxowlet/fol/interpreter/model/type/WholeNumberType.java
+++ b/fol-interpreter/src/main/java/com/foxowlet/fol/interpreter/model/type/WholeNumberType.java
@@ -3,7 +3,7 @@ package com.foxowlet.fol.interpreter.model.type;
 import com.foxowlet.fol.interpreter.exception.IncompatibleTypeException;
 import com.foxowlet.fol.interpreter.exception.InvalidTypeSizeException;
 
-public abstract class WholeNumberType<T extends Number> implements Type {
+public abstract class WholeNumberType<T extends Number> implements TypeDescriptor {
     private final Class<T> javaClass;
     private final String folTypeName;
 

--- a/fol-interpreter/src/main/java/com/foxowlet/fol/interpreter/predefined/PredefinedTypes.java
+++ b/fol-interpreter/src/main/java/com/foxowlet/fol/interpreter/predefined/PredefinedTypes.java
@@ -2,21 +2,19 @@ package com.foxowlet.fol.interpreter.predefined;
 
 import com.foxowlet.fol.interpreter.ContextPreprocessor;
 import com.foxowlet.fol.interpreter.InterpretationContext;
-import com.foxowlet.fol.interpreter.model.type.ByteType;
-import com.foxowlet.fol.interpreter.model.type.IntType;
-import com.foxowlet.fol.interpreter.model.type.LongType;
-import com.foxowlet.fol.interpreter.model.type.Type;
+import com.foxowlet.fol.interpreter.model.type.*;
 
 import java.util.List;
 
 public class PredefinedTypes implements ContextPreprocessor {
-    private final List<Type> predefinedTypes;
+    private final List<TypeDescriptor> predefinedTypes;
 
     public PredefinedTypes() {
         predefinedTypes = List.of(
                 new ByteType(),
                 new IntType(),
-                new LongType()
+                new LongType(),
+                new UnitType()
         );
     }
 

--- a/fol-interpreter/src/main/java/com/foxowlet/fol/interpreter/type/TypeInterpreter.java
+++ b/fol-interpreter/src/main/java/com/foxowlet/fol/interpreter/type/TypeInterpreter.java
@@ -13,7 +13,7 @@ public class TypeInterpreter {
             case ScalarType scalar ->
                     context.interpret(scalar.symbol(), TypeDescriptor.class);
             case FunctionType(Type argumentType, Type returnType) ->
-                new FunctionTypeDescriptor(context, interpret(argumentType, context), interpret(returnType, context));
+                    new FunctionTypeDescriptor(context, interpret(argumentType, context), interpret(returnType, context));
         };
     }
 }

--- a/fol-interpreter/src/main/java/com/foxowlet/fol/interpreter/type/TypeInterpreter.java
+++ b/fol-interpreter/src/main/java/com/foxowlet/fol/interpreter/type/TypeInterpreter.java
@@ -1,0 +1,19 @@
+package com.foxowlet.fol.interpreter.type;
+
+import com.foxowlet.fol.ast.FunctionType;
+import com.foxowlet.fol.ast.ScalarType;
+import com.foxowlet.fol.ast.Type;
+import com.foxowlet.fol.interpreter.model.type.FunctionTypeDescriptor;
+import com.foxowlet.fol.interpreter.model.type.TypeDescriptor;
+import com.foxowlet.fol.interpreter.InterpretationContext;
+
+public class TypeInterpreter {
+    public TypeDescriptor interpret(Type type, InterpretationContext context) {
+        return switch (type) {
+            case ScalarType scalar ->
+                    context.interpret(scalar.symbol(), TypeDescriptor.class);
+            case FunctionType(Type argumentType, Type returnType) ->
+                new FunctionTypeDescriptor(context, interpret(argumentType, context), interpret(returnType, context));
+        };
+    }
+}

--- a/fol-interpreter/src/test/java/com/foxowlet/fol/interpreter/AbstractInterpreterTest.java
+++ b/fol-interpreter/src/test/java/com/foxowlet/fol/interpreter/AbstractInterpreterTest.java
@@ -2,7 +2,11 @@ package com.foxowlet.fol.interpreter;
 
 import com.foxowlet.fol.ast.Expression;
 import com.foxowlet.fol.emulator.Emulator;
+import com.foxowlet.fol.interpreter.model.Function;
 import com.foxowlet.fol.interpreter.model.Value;
+import com.foxowlet.fol.interpreter.model.Variable;
+import com.foxowlet.fol.interpreter.model.type.FunctionTypeDescriptor;
+import com.foxowlet.fol.interpreter.model.type.TypeDescriptor;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -25,5 +29,17 @@ public class AbstractInterpreterTest {
     protected static <T> void assertValue(T expected, Object value) {
         assertInstanceOf(Value.class, value);
         assertEquals(expected, ((Value) value).value());
+    }
+
+    protected static void assertFunctionType(Variable function, TypeDescriptor... parts) {
+        TypeDescriptor type = function.type();
+        int lastIndex = parts.length - 1;
+        for (int i = 0; i < lastIndex; i++) {
+            FunctionTypeDescriptor ftype = assertInstanceOf(FunctionTypeDescriptor.class, type);
+            TypeDescriptor part = parts[i];
+            assertEquals(part, ftype.argumentType());
+            type = ftype.returnType();
+        }
+        assertEquals(parts[lastIndex], type);
     }
 }

--- a/fol-interpreter/src/test/java/com/foxowlet/fol/interpreter/expression/AssignmentTest.java
+++ b/fol-interpreter/src/test/java/com/foxowlet/fol/interpreter/expression/AssignmentTest.java
@@ -12,7 +12,7 @@ class AssignmentTest extends AbstractInterpreterTest {
     @Test
     void shouldReturnAssignedValue() {
         Expression assignment = new Assignment(
-                new VarDecl(new Symbol("foo"), new Symbol("Int")),
+                new VarDecl(new Symbol("foo"), new ScalarType(new Symbol("Int"))),
                 new IntLiteral(42));
 
         Object actual = interpret(assignment);

--- a/fol-interpreter/src/test/java/com/foxowlet/fol/interpreter/expression/BlockTest.java
+++ b/fol-interpreter/src/test/java/com/foxowlet/fol/interpreter/expression/BlockTest.java
@@ -12,11 +12,11 @@ class BlockTest extends AbstractInterpreterTest {
     void shouldReturnLastExpressionValue() {
         // var i: Int = 40 + 42
         Expression expr1 = new Assignment(
-                new VarDecl(new Symbol("i"), new Symbol("Int")),
+                new VarDecl(new Symbol("i"), new ScalarType(new Symbol("Int"))),
                 new Addition(new IntLiteral(40), new IntLiteral(42)));
         // var j: Int = i + 10;
         Expression expr2 = new Assignment(
-                new VarDecl(new Symbol("j"), new Symbol("Int")),
+                new VarDecl(new Symbol("j"), new ScalarType(new Symbol("Int"))),
                 new Addition(new Symbol("i"), new IntLiteral(10)));
         // { ... }
         Expression block = new Block(List.of(expr1, expr2));

--- a/fol-interpreter/src/test/java/com/foxowlet/fol/interpreter/expression/FunctionCallInterpreterTest.java
+++ b/fol-interpreter/src/test/java/com/foxowlet/fol/interpreter/expression/FunctionCallInterpreterTest.java
@@ -1,0 +1,44 @@
+package com.foxowlet.fol.interpreter.expression;
+
+import com.foxowlet.fol.ast.*;
+import com.foxowlet.fol.interpreter.AbstractInterpreterTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+
+class FunctionCallInterpreterTest extends AbstractInterpreterTest {
+    @Test
+    void shouldCallFunctionFromVariable() {
+        ScalarType argumentType = new ScalarType(new Symbol("Unit"));
+        ScalarType returnType = new ScalarType(new Symbol("Int"));
+        // val foo: Unit->Int
+        VarDecl var = new VarDecl(new Symbol("foo"), new FunctionType(argumentType, returnType));
+        Block body = new Block(List.of(new IntLiteral(42)));
+        // #(){ 42 }
+        Lambda lambda = new Lambda(List.of(), body);
+        // val foo: Unit->Int = #(){ 42 }
+        Assignment assignment = new Assignment(var, lambda);
+        // foo()
+        FunctionCall functionCall = new FunctionCall(new Symbol("foo"), List.of());
+        // { ... }
+        Block block = new Block(List.of(assignment, functionCall));
+
+        Object actual = interpret(block);
+
+        assertValue(42, actual);
+    }
+
+
+    @Test
+    void shouldCallFunction_whenCalledInplace() {
+        Block body = new Block(List.of(new IntLiteral(42)));
+        Lambda lambda = new Lambda(List.of(), body);
+        // #(){ 42 }()
+        FunctionCall functionCall = new FunctionCall(lambda, List.of());
+
+        Object actual = interpret(functionCall);
+
+        assertValue(42, actual);
+    }
+}

--- a/fol-interpreter/src/test/java/com/foxowlet/fol/interpreter/expression/FunctionDeclInterpreterTest.java
+++ b/fol-interpreter/src/test/java/com/foxowlet/fol/interpreter/expression/FunctionDeclInterpreterTest.java
@@ -1,0 +1,56 @@
+package com.foxowlet.fol.interpreter.expression;
+
+import com.foxowlet.fol.ast.*;
+import com.foxowlet.fol.interpreter.AbstractInterpreterTest;
+import com.foxowlet.fol.interpreter.model.Function;
+import com.foxowlet.fol.interpreter.model.Variable;
+import com.foxowlet.fol.interpreter.model.type.*;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+class FunctionDeclInterpreterTest extends AbstractInterpreterTest {
+    @Test
+    void shouldCreateBoundSymbol() {
+        Block body = new Block(List.of());
+        ScalarType returnType = new ScalarType(new Symbol("Unit"));
+        // def foo(): Unit {}
+        FunctionDecl foo = new FunctionDecl(new Symbol("foo"), List.of(), returnType, body);
+
+        Object actual = interpret(foo);
+
+        assertValue(new Function(1, List.of(), body), actual);
+    }
+
+    @Test
+    void shouldComputeProperType_whenNoArgs() {
+        Block body = new Block(List.of(new IntLiteral(42)));
+        ScalarType returnType = new ScalarType(new Symbol("Int"));
+        // def foo(): Int { 42 }
+        FunctionDecl foo = new FunctionDecl(new Symbol("foo"), List.of(), returnType, body);
+
+        Object actual = interpret(foo);
+
+        Variable variable = assertInstanceOf(Variable.class, actual);
+        assertFunctionType(variable, new UnitType(), new IntType());
+    }
+
+    @Test
+    void shouldComputeProperType_whenMultipleArgs() {
+        Block body = new Block(List.of());
+        ScalarType returnType = new ScalarType(new Symbol("Unit"));
+        List<FormalParameter> params = List.of(
+                new FormalParameter(new Symbol("a"), new ScalarType(new Symbol("Long"))),
+                new FormalParameter(new Symbol("b"), new ScalarType(new Symbol("Byte")))
+        );
+        // def foo(a: Long, b: Byte): Unit {}
+        FunctionDecl foo = new FunctionDecl(new Symbol("foo"), params, returnType, body);
+
+        Object actual = interpret(foo);
+
+        Variable variable = assertInstanceOf(Variable.class, actual);
+        assertFunctionType(variable, new LongType(), new ByteType(), new UnitType());
+    }
+}

--- a/fol-interpreter/src/test/java/com/foxowlet/fol/interpreter/expression/LambdaInterpreterTest.java
+++ b/fol-interpreter/src/test/java/com/foxowlet/fol/interpreter/expression/LambdaInterpreterTest.java
@@ -1,0 +1,26 @@
+package com.foxowlet.fol.interpreter.expression;
+
+import com.foxowlet.fol.ast.*;
+import com.foxowlet.fol.interpreter.AbstractInterpreterTest;
+import com.foxowlet.fol.interpreter.model.Function;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+
+class LambdaInterpreterTest extends AbstractInterpreterTest {
+    @Test
+    void shouldAssignFunctionToVariable() {
+        ScalarType argumentType = new ScalarType(new Symbol("Unit"));
+        ScalarType returnType = new ScalarType(new Symbol("Int"));
+        VarDecl var = new VarDecl(new Symbol("foo"), new FunctionType(argumentType, returnType));
+        Block body = new Block(List.of(new IntLiteral(42)));
+        Lambda lambda = new Lambda(List.of(), body);
+        Assignment assignment = new Assignment(var, lambda);
+
+        Object actual = interpret(assignment);
+
+        assertValue(new Function(1, List.of(), body), actual);
+    }
+
+}

--- a/fol-interpreter/src/test/java/com/foxowlet/fol/interpreter/expression/LambdaInterpreterTest.java
+++ b/fol-interpreter/src/test/java/com/foxowlet/fol/interpreter/expression/LambdaInterpreterTest.java
@@ -7,8 +7,20 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 
 class LambdaInterpreterTest extends AbstractInterpreterTest {
+    @Test
+    void shouldInterpretAsFunction() {
+        Block body = new Block(List.of(new IntLiteral(42)));
+        Lambda lambda = new Lambda(List.of(), body);
+
+        Object actual = interpret(lambda);
+
+        assertEquals(new Function(1, List.of(), body), actual);
+    }
+
     @Test
     void shouldAssignFunctionToVariable() {
         ScalarType argumentType = new ScalarType(new Symbol("Unit"));

--- a/fol-interpreter/src/test/java/com/foxowlet/fol/interpreter/expression/VarDeclTest.java
+++ b/fol-interpreter/src/test/java/com/foxowlet/fol/interpreter/expression/VarDeclTest.java
@@ -1,6 +1,7 @@
 package com.foxowlet.fol.interpreter.expression;
 
 import com.foxowlet.fol.ast.Expression;
+import com.foxowlet.fol.ast.ScalarType;
 import com.foxowlet.fol.ast.Symbol;
 import com.foxowlet.fol.ast.VarDecl;
 import com.foxowlet.fol.interpreter.AbstractInterpreterTest;
@@ -14,7 +15,7 @@ class VarDeclTest extends AbstractInterpreterTest {
 
     @Test
     void shouldAllocateVariable() {
-        Expression varDecl = new VarDecl(new Symbol("foo"), new Symbol("Long"));
+        Expression varDecl = new VarDecl(new Symbol("foo"), new ScalarType(new Symbol("Long")));
 
         Object actual = interpret(varDecl);
 
@@ -24,7 +25,7 @@ class VarDeclTest extends AbstractInterpreterTest {
 
     @Test
     void shouldThrowException_whenTypeIsUnresolved() {
-        VarDecl varDecl = new VarDecl(new Symbol("foo"), new Symbol("bar"));
+        VarDecl varDecl = new VarDecl(new Symbol("foo"), new ScalarType(new Symbol("bar")));
 
         assertThrows(InterpreterException.class, () -> interpret(varDecl));
     }

--- a/fol-ir/src/main/java/com/foxowlet/fol/ast/Expression.java
+++ b/fol-ir/src/main/java/com/foxowlet/fol/ast/Expression.java
@@ -2,5 +2,5 @@ package com.foxowlet.fol.ast;
 
 public sealed interface Expression extends Node
         permits VarDecl, Assignment, Literal, Symbol, ArithmeticExpression, Block,
-        Lambda, FunctionCall {
+        Lambda, FunctionCall, FunctionDecl {
 }

--- a/fol-ir/src/main/java/com/foxowlet/fol/ast/Expression.java
+++ b/fol-ir/src/main/java/com/foxowlet/fol/ast/Expression.java
@@ -1,5 +1,6 @@
 package com.foxowlet.fol.ast;
 
 public sealed interface Expression extends Node
-        permits VarDecl, Assignment, Literal, Symbol, ArithmeticExpression, Block {
+        permits VarDecl, Assignment, Literal, Symbol, ArithmeticExpression, Block,
+        Lambda, FunctionCall {
 }

--- a/fol-ir/src/main/java/com/foxowlet/fol/ast/FormalParameter.java
+++ b/fol-ir/src/main/java/com/foxowlet/fol/ast/FormalParameter.java
@@ -1,0 +1,4 @@
+package com.foxowlet.fol.ast;
+
+public record FormalParameter(Symbol name, Type type) implements Node {
+}

--- a/fol-ir/src/main/java/com/foxowlet/fol/ast/FunctionCall.java
+++ b/fol-ir/src/main/java/com/foxowlet/fol/ast/FunctionCall.java
@@ -1,0 +1,6 @@
+package com.foxowlet.fol.ast;
+
+import java.util.List;
+
+public record FunctionCall(Expression target, List<Expression> arguments) implements Expression {
+}

--- a/fol-ir/src/main/java/com/foxowlet/fol/ast/FunctionDecl.java
+++ b/fol-ir/src/main/java/com/foxowlet/fol/ast/FunctionDecl.java
@@ -1,0 +1,6 @@
+package com.foxowlet.fol.ast;
+
+import java.util.List;
+
+public record FunctionDecl(Symbol name, List<FormalParameter> params, Type returnType, Block body) implements Expression {
+}

--- a/fol-ir/src/main/java/com/foxowlet/fol/ast/FunctionDecl.java
+++ b/fol-ir/src/main/java/com/foxowlet/fol/ast/FunctionDecl.java
@@ -2,5 +2,6 @@ package com.foxowlet.fol.ast;
 
 import java.util.List;
 
-public record FunctionDecl(Symbol name, List<FormalParameter> params, Type returnType, Block body) implements Expression {
+public record FunctionDecl(Symbol name, List<FormalParameter> params, Type returnType, Block body)
+        implements Expression {
 }

--- a/fol-ir/src/main/java/com/foxowlet/fol/ast/FunctionType.java
+++ b/fol-ir/src/main/java/com/foxowlet/fol/ast/FunctionType.java
@@ -1,0 +1,4 @@
+package com.foxowlet.fol.ast;
+
+public record FunctionType(Type argumentType, Type returnType) implements Type {
+}

--- a/fol-ir/src/main/java/com/foxowlet/fol/ast/Lambda.java
+++ b/fol-ir/src/main/java/com/foxowlet/fol/ast/Lambda.java
@@ -1,0 +1,6 @@
+package com.foxowlet.fol.ast;
+
+import java.util.List;
+
+public record Lambda(List<FormalParameter> params, Block body) implements Expression {
+}

--- a/fol-ir/src/main/java/com/foxowlet/fol/ast/ScalarType.java
+++ b/fol-ir/src/main/java/com/foxowlet/fol/ast/ScalarType.java
@@ -1,0 +1,4 @@
+package com.foxowlet.fol.ast;
+
+public record ScalarType(Symbol symbol) implements Type {
+}

--- a/fol-ir/src/main/java/com/foxowlet/fol/ast/Type.java
+++ b/fol-ir/src/main/java/com/foxowlet/fol/ast/Type.java
@@ -1,0 +1,5 @@
+package com.foxowlet.fol.ast;
+
+public sealed interface Type extends Node
+        permits ScalarType, FunctionType {
+}

--- a/fol-ir/src/main/java/com/foxowlet/fol/ast/VarDecl.java
+++ b/fol-ir/src/main/java/com/foxowlet/fol/ast/VarDecl.java
@@ -1,4 +1,4 @@
 package com.foxowlet.fol.ast;
 
-public record VarDecl(Symbol variable, Symbol type) implements Expression {
+public record VarDecl(Symbol variable, Type type) implements Expression {
 }


### PR DESCRIPTION
Changes:  
- Lambda functions and function calls added to the syntax model (internal representation)  
- Symbols are replaced with specialized instances for type declarations (IR)
- Support lambda functions as first-class citizens in the interpreter
- Support function calls in the interpreter
- Support for function types and `Unit` 
- Syntax sugar for named function declarations